### PR TITLE
Fix UserInfo URL

### DIFF
--- a/src/Provider/Drupal.php
+++ b/src/Provider/Drupal.php
@@ -49,7 +49,7 @@ class Drupal extends AbstractProvider
      */
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        return $this->getBaseUrl() . '/oauth2/userInfo';
+        return $this->getBaseUrl() . '/oauth2/UserInfo';
     }
 
     /**


### PR DESCRIPTION
The userInfo path on server side is defined as UserInfo.
But the client tries to call userInfo, resulting in a 404.

Reference server code: http://cgit.drupalcode.org/oauth2_server/tree/oauth2_server.routing.yml?id=b4b20096512879ac2c48a158fce087f522bbc48e#n21

Please note that the controller function is userInfo but the path is UserInfo

```
modified:   src/Provider/Drupal.php
```

[anshup@mouthwa oauth2-drupal]$ ./vendor/bin/phpunit 
PHPUnit 4.8.24 by Sebastian Bergmann and contributors.
Warning:    The Xdebug extension is not loaded
        No code coverage will be generated.

.......

Time: 107 ms, Memory: 6.50MB

OK (7 tests, 27 assertions)
[anshup@mouthwa oauth2-drupal]$ ./vendor/bin/phpcs src --standard=psr2 -sp
..

Time: 62ms; Memory: 5.25Mb
