### PR TITLE
Correct paths: oauth2 -> oauth

### DIFF
--- a/src/Provider/Drupal.php
+++ b/src/Provider/Drupal.php
@@ -27,7 +27,7 @@ class Drupal extends AbstractProvider
      */
     public function getBaseAuthorizationUrl()
     {
-        return $this->getBaseUrl() . '/oauth2/authorize';
+        return $this->getBaseUrl() . '/oauth/authorize';
     }
 
     /**
@@ -38,7 +38,7 @@ class Drupal extends AbstractProvider
      */
     public function getBaseAccessTokenUrl(array $params)
     {
-        return $this->getBaseUrl() . '/oauth2/token';
+        return $this->getBaseUrl() . '/oauth/token';
     }
 
     /**
@@ -49,7 +49,7 @@ class Drupal extends AbstractProvider
      */
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        return $this->getBaseUrl() . '/oauth2/UserInfo';
+        return $this->getBaseUrl() . '/oauth/UserInfo';
     }
 
     /**


### PR DESCRIPTION
...to get in sync with the current implementation of the server: see https://www.drupal.org/project/simple_oauth, source file is https://git.drupalcode.org/project/simple_oauth/-/blob/5.x/simple_oauth.routing.yml. The client only works with that server after changing the paths in the client source. Seems that the server code is more recent than this client (maybe outdated)?